### PR TITLE
Fix TestNotSupportedSelectors test case

### DIFF
--- a/premailer/selector_compatible_test.go
+++ b/premailer/selector_compatible_test.go
@@ -107,8 +107,6 @@ func TestNotSupportedSelectors(t *testing.T) {
 	}
 
 	for _, selector := range notSupportedSelectors {
-		assert.Panics(t, func() {
-			pr.doc.Find(selector)
-		})
+		assert.Equal(t, 0, pr.doc.Find(selector).Length())
 	}
 }


### PR DESCRIPTION
As far as I can understand goquery decided to change the behaviour of
their API in case of invalid/unsupported selectors:
instead of panic-ing, they return an empty selection.
For more details please refer to
https://github.com/PuerkitoBio/goquery/commit/2ab590df05344e1c8da3929b4a3b2aefe56705c0