### PR TITLE
Added a KeepBangImportant option to preserve '!important' in final style attribute.

### DIFF
--- a/premailer/element.go
+++ b/premailer/element.go
@@ -14,6 +14,7 @@ type elementRules struct {
 	element         *goquery.Selection
 	rules           []*styleRule
 	cssToAttributes bool
+	keepBangImportant bool
 }
 
 func (er *elementRules) inline() {
@@ -30,6 +31,9 @@ func (er *elementRules) inline() {
 		for _, s := range rule.styles {
 			prop := s.Property
 			styles[prop] = s.Value
+			if er.keepBangImportant && s.Important == 1 {
+				styles[prop] += " !important"
+			}
 			orders = append(orders, prop)
 		}
 	}
@@ -78,6 +82,11 @@ func (er *elementRules) styleToBasicHtmlAttribute(prop, value string) {
 	case "width":
 		fallthrough
 	case "height":
+		// If we are keeping "!important" in our styles, we need to strip it out
+		// here so that the proper px value can be parsed
+		if er.keepBangImportant {
+			value = strings.Replace(value, " !important", "", 1)
+		}
 		if strings.HasSuffix(value, "px") {
 			value = value[:len(value)-2]
 			er.element.SetAttr(prop, value)

--- a/premailer/options.go
+++ b/premailer/options.go
@@ -8,11 +8,20 @@ type Options struct {
 	// Copy related CSS properties into HTML attributes (e.g. background-color to bgcolor)
 	// Default true
 	CssToAttributes bool
+
+	// If true, then style declarations that have "!important" will keep the "!important" in the final
+	// style attribute
+	// Example:
+	//		<style>p { width: 100% !important }</style><p>Text</p>
+	// gives
+	//		<p style="width: 100% !important">Text</p>
+	KeepBangImportant bool
 }
 
 // NewOptions return an Options instance with default value
 func NewOptions() *Options {
 	options := &Options{}
 	options.CssToAttributes = true
+	options.KeepBangImportant = false
 	return options
 }

--- a/premailer/premailer.go
+++ b/premailer/premailer.go
@@ -133,7 +133,12 @@ func (pr *premailer) collectElements() {
 				s.SetAttr(pr.elIdAttr, id)
 				rules := make([]*styleRule, 0)
 				rules = append(rules, rule)
-				pr.elements[id] = &elementRules{element: s, rules: rules, cssToAttributes: pr.options.CssToAttributes}
+				pr.elements[id] = &elementRules{
+					element: s,
+					rules: rules,
+					cssToAttributes: pr.options.CssToAttributes,
+					keepBangImportant: pr.options.KeepBangImportant,
+				}
 				pr.elementId += 1
 			}
 		})

--- a/premailer/premailer_test.go
+++ b/premailer/premailer_test.go
@@ -260,6 +260,43 @@ func TestWithImportant(t *testing.T) {
 	assert.Contains(t, resultHTML, "<p class=\"wide\" style=\"color:blue;width:100px\" width=\"100\"><strong>Yes!</strong></p>")
 }
 
+
+func TestWithKeepImportant(t *testing.T) {
+	html := `<html>
+        <head>
+        <title>Title</title>
+        <style type="text/css">
+        h1, h2 {
+        	color:red;
+        }
+        p {
+        	width: 100px !important;
+        	color: blue
+        }
+        .wide {
+        	width: 1000px;
+        }		
+        </style>
+        </head>
+        <body>
+        <h1>Hi!</h1>
+        <p class="wide"><strong>Yes!</strong></p>
+        </body>
+        </html>`
+
+	options := NewOptions()
+	options.KeepBangImportant = true
+	p, err := NewPremailerFromString(html, options)
+	assert.Nil(t, err)
+	resultHTML, err := p.Transform()
+	assert.Nil(t, err)
+
+	assert.Contains(t, resultHTML, "<h1 style=\"color:red\">Hi!</h1>")
+	assert.Contains(t, resultHTML, "<p class=\"wide\" style=\"color:blue;width:100px !important\" width=\"100\"><strong>Yes!</strong></p>")
+
+}
+
+
 func TestWithMediaRule(t *testing.T) {
 	html := `<html>
         <head>


### PR DESCRIPTION
My final output needed to have `margin: 0 auto !important` in the style attribute to work properly with the template I was using.

I added this option and tests to achieve that.