### PR TITLE
Fix for escaped leftover css rules

### DIFF
--- a/premailer/data/leftover_test.html
+++ b/premailer/data/leftover_test.html
@@ -1,0 +1,20 @@
+<html>
+
+<head>
+    <style>
+        div {
+            background-color: red;
+            padding: 10px;
+        }
+
+        .a:hover {
+            background-color: green;
+        }
+    </style>
+</head>
+
+<body>
+    <div class="a">Hover me!</div>
+</body>
+
+</html>

--- a/premailer/premailer_from_file_test.go
+++ b/premailer/premailer_from_file_test.go
@@ -19,6 +19,16 @@ func TestBasicHTMLFromFile(t *testing.T) {
 	assert.Contains(t, resultHTML, "<div style=\"background-color:green\">Green color</div>")
 }
 
+func TestLeftoverCssRules(t *testing.T) {
+	p, err := NewPremailerFromFile("data/leftover_test.html", nil)
+	assert.Nil(t, err)
+	resultHTML, err := p.Transform()
+	assert.Nil(t, err)
+
+	assert.Contains(t, resultHTML, "<div class=\"a\" style=\"background-color:red;padding:10px\">Hover me!</div>")
+	assert.Contains(t, resultHTML, "<style type=\"text/css\">.a:hover {\nbackground-color: green !important\n}</style>")
+}
+
 func TestFromFileNotFound(t *testing.T) {
 	p, err := NewPremailerFromFile("data/blablabla.html", nil)
 	assert.NotNil(t, err)

--- a/premailer/util.go
+++ b/premailer/util.go
@@ -10,7 +10,7 @@ func copyRule(selector string, rule *css.CSSRule) *css.CSSRule {
 	for _, s := range rule.Style.Styles {
 		styles = append(styles, css.NewCSSStyleDeclaration(s.Property, s.Value.Text(), s.Important))
 	}
-	copiedStyle := css.CSSStyleRule{Selector: css.NewCSSValueString(selector), Styles: styles}
+	copiedStyle := css.CSSStyleRule{Selector: css.NewCSSValue(selector), Styles: styles}
 	copiedRule := &css.CSSRule{Type: rule.Type, Style: copiedStyle}
 	return copiedRule
 }


### PR DESCRIPTION
fixes https://github.com/vanng822/go-premailer/issues/17