### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,5 +1,8 @@
 name: Go
 
+permissions:
+  contents: read
+
 on:
   push:
     branches: [ "master" ]


### PR DESCRIPTION
Potential fix for [https://github.com/vanng822/go-premailer/security/code-scanning/1](https://github.com/vanng822/go-premailer/security/code-scanning/1)

To fix the problem, the workflow should explicitly define the `permissions` block either at the root level of the workflow or within the specific job. Since all jobs in this workflow appear to share the same purpose (building, testing, and running tools against the repository contents), adding a `permissions` block at the root level of the workflow is the most efficient approach.

The recommended permissions are `contents: read`, which grants read-only access to repository contents, and this should suffice for the operations in the workflow.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
